### PR TITLE
Add summary of events to top of meeting notes

### DIFF
--- a/docs/2023-06-08-meeting.md
+++ b/docs/2023-06-08-meeting.md
@@ -27,6 +27,16 @@ ignored and if you spam we'll delete your comments and block you from the org.
 ## Agenda
 We have about an hour so let's spend 15 minutes on each topic max.
 
+### Summary of Incident and Response
+
+(this is mostly for the benefit of attendees to get them caught up quickly - this doesn't need to be read aloud or something)
+
+`fractureiser` is a novel self replicating virus that infects Bukkit plugins, Forge Mods, Fabric Mods, and vanilla Minecraft JARs. Infected JARs, upon being loaded, will run as normal, but silently download a series of payloads that steal login tokens, stored browser passwords/payment information, and cryptocurrency. After a computer has been infected, every applicable JAR file on the compromised system will be infected such that if they are shared and run on an another computer, the infection will spread. Compromised Curseforge login tokens were used to gain access to large mod projects and distribute infected JARs to users.
+
+Discussion and responses to the issue began in earnest on June 6th. Samples were gradually discovered, identified, and decompiled. The source of the payloads that propogate the malware and steal passwords/tokens was identified, and swiftly taken down by its host, Serverion. Infected JARs are no longer able to progress or propogate the malware, but infections from prior to the node being taken down may still be active.
+
+At time of writing, samples continue to be reverse engineered in the hopes that, should the attackers attempt to create a new iteration of the malware, its command and control nodes can be taken down as quickly as possible. On June 7th, the attacker attempted to create a new node, which was again swiftly taken down by its host. A web URL pointing to this now-defunct node has been found, and is being actively monitored.
+
 ### Opaque Review Processes/Security by Obscurity
 
 #### Discussion and action items

--- a/docs/2023-06-08-meeting.md
+++ b/docs/2023-06-08-meeting.md
@@ -24,10 +24,7 @@ ignored and if you spam we'll delete your comments and block you from the org.
 * TODO (FTB contacts)
 * TODO (Forge contacts)
 
-## Agenda
-We have about an hour so let's spend 15 minutes on each topic max.
-
-### Summary of Incident and Response
+## Summary of Incident and Response
 
 (this is mostly for the benefit of attendees to get them caught up quickly - this doesn't need to be read aloud or something)
 
@@ -36,6 +33,9 @@ We have about an hour so let's spend 15 minutes on each topic max.
 Discussion and responses to the issue began in earnest on June 6th. Samples were gradually discovered, identified, and decompiled. The source of the payloads that propogate the malware and steal passwords/tokens was identified, and swiftly taken down by its host, Serverion. Infected JARs are no longer able to progress or propogate the malware, but infections from prior to the node being taken down may still be active.
 
 At time of writing, samples continue to be reverse engineered in the hopes that, should the attackers attempt to create a new iteration of the malware, its command and control nodes can be taken down as quickly as possible. On June 7th, the attacker attempted to create a new node, which was again swiftly taken down by its host. A web URL pointing to this now-defunct node has been found, and is being actively monitored.
+
+## Agenda
+We have about an hour so let's spend 15 minutes on each topic max.
 
 ### Opaque Review Processes/Security by Obscurity
 


### PR DESCRIPTION
I want feedback on the phrasing and completeness of events. I figure not everyone involved in the meeting has been following this as closely as us, so a summary of the basic information and attack vectors is important.